### PR TITLE
Fix output format to suppress warnings

### DIFF
--- a/cliff_detector/src/cliff_detector_node.cpp
+++ b/cliff_detector/src/cliff_detector_node.cpp
@@ -112,7 +112,7 @@ rcl_interfaces::msg::SetParametersResult CliffDetectorNode::parametersCallback(
     }
     detector_.setParametersConfigurated(false);
   } catch (const std::exception & e) {
-    RCLCPP_ERROR(this->get_logger(), e.what());
+    RCLCPP_ERROR(this->get_logger(), "%s", e.what());
   }
 
   return result;


### PR DESCRIPTION
clang-tidy's warning is like below.

```
warning: format string is not a string literal (potentially insecure) [clang-diagnostic-format-security]
```